### PR TITLE
Update README to include link to AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ To install libE131 in your system, download the [latest release archive][release
 The last step requires `root` privileges. You can uninstall the library using:
 
     $ sudo make uninstall
+    
+A development package is also available on the [AUR][aur-link].
 
 [releases]: https://github.com/hhromic/libe131/releases/latest
+[aur-link]: https://aur.archlinux.org/packages/libe131-git/
 
 ## E1.31 (sACN) Packets
 


### PR DESCRIPTION
Hi, 

Since I'm using the library on quite a few devices that run Arch Linux, I've made a VCS-linked package for ``libe131`` on the AUR. It can be found at: [https://aur.archlinux.org/packages/libe131-git/](url).

Could be useful to put a link in the README so it could be easily seen by others wishing to use it on Arch-based distros.