### PR TITLE
Match package version in soversion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,4 +9,4 @@ libe131_la_LDFLAGS = -export-symbols-regex '^[eE]131_[^_]'
 include_HEADERS = src/e131.h
 
 # see: https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-libe131_la_LDFLAGS += -version-info 1:4:0
+libe131_la_LDFLAGS += -version-info 5:0:4


### PR DESCRIPTION
Right now when building the shared library, it comes out as .so.1.0.4.
