### PR TITLE
Add being able to bind a multicast socket to a specific host IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ See the examples sections to see how the most common API functions are used with
 
 * `int e131_multicast_join_iface(int sockfd, const uint16_t universe, const int ifindex)`: Join a socket file descriptor to an E1.31 multicast group using a universe and a specific network interface. On error, -1 is returned, and `errno` is set appropriately.
 
+* `int e131_multicast_join_ifaddr(int sockfd, const uint16_t universe, const char *ifaddr)`: Join a socket file descriptor to an E1.31 multicast group using a universe and an IP address to bind to. On error, -1 is returned, and `errno` is set appropriately.
+
 * `int e131_pkt_init(e131_packet_t *packet, const uint16_t universe, const uint16_t num_slots)`:  Initialize an E1.31 packet using a universe and a number of slots. On success, zero is returned. On error, -1 is returned, and `errno` is set appropriately.
 
 * `bool e131_get_option(const e131_packet_t *packet, const e131_option_t option)`: Get the state of a framing option in an E1.31 packet.

--- a/src/e131.c
+++ b/src/e131.c
@@ -178,7 +178,6 @@ extern int e131_multicast_join_ifaddr(int sockfd, const uint16_t universe, const
   struct ip_mreq mreq;
   mreq.imr_multiaddr.s_addr = htonl(0xefff0000 | universe);
   mreq.imr_interface.s_addr = inet_addr(ifaddr);
-  mreq.imr_ifindex = 0;
 #else
   struct ip_mreqn mreq;
   mreq.imr_multiaddr.s_addr = htonl(0xefff0000 | universe);

--- a/src/e131.c
+++ b/src/e131.c
@@ -166,24 +166,26 @@ int e131_multicast_join_iface(int sockfd, const uint16_t universe, const int ifi
 
 /* Join a socket file descriptor to an E1.31 multicast group using a universe and an IP address to bind to */
 extern int e131_multicast_join_ifaddr(int sockfd, const uint16_t universe, const char *ifaddr) {
-    if (universe < 1 || universe > 63999) {
-        errno = EINVAL;
-        return -1;
-    }
+  if (universe < 1 || universe > 63999) {
+    errno = EINVAL;
+    return -1;
+  }
 #ifdef _WIN32
-    if (ifindex != 0) {
+  if (ifindex != 0) {
     errno = ENOSYS;
     return -1;
   }
   struct ip_mreq mreq;
   mreq.imr_multiaddr.s_addr = htonl(0xefff0000 | universe);
   mreq.imr_interface.s_addr = inet_addr(ifaddr);
+  mreq.imr_ifindex = 0;
 #else
-    struct ip_mreqn mreq;
-    mreq.imr_multiaddr.s_addr = htonl(0xefff0000 | universe);
-    mreq.imr_address.s_addr = inet_addr(ifaddr);
+  struct ip_mreqn mreq;
+  mreq.imr_multiaddr.s_addr = htonl(0xefff0000 | universe);
+  mreq.imr_address.s_addr = inet_addr(ifaddr);
+  mreq.imr_ifindex = 0;
 #endif
-    return setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof mreq);
+  return setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof mreq);
 }
 
 /* Initialize an E1.31 packet using a universe and a number of slots */

--- a/src/e131.c
+++ b/src/e131.c
@@ -171,10 +171,6 @@ extern int e131_multicast_join_ifaddr(int sockfd, const uint16_t universe, const
     return -1;
   }
 #ifdef _WIN32
-  if (ifindex != 0) {
-    errno = ENOSYS;
-    return -1;
-  }
   struct ip_mreq mreq;
   mreq.imr_multiaddr.s_addr = htonl(0xefff0000 | universe);
   mreq.imr_interface.s_addr = inet_addr(ifaddr);

--- a/src/e131.c
+++ b/src/e131.c
@@ -164,6 +164,28 @@ int e131_multicast_join_iface(int sockfd, const uint16_t universe, const int ifi
   return setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof mreq);
 }
 
+/* Join a socket file descriptor to an E1.31 multicast group using a universe and an IP address to bind to */
+extern int e131_multicast_join_ifaddr(int sockfd, const uint16_t universe, const char *ifaddr) {
+    if (universe < 1 || universe > 63999) {
+        errno = EINVAL;
+        return -1;
+    }
+#ifdef _WIN32
+    if (ifindex != 0) {
+    errno = ENOSYS;
+    return -1;
+  }
+  struct ip_mreq mreq;
+  mreq.imr_multiaddr.s_addr = htonl(0xefff0000 | universe);
+  mreq.imr_interface.s_addr = inet_addr(ifaddr);
+#else
+    struct ip_mreqn mreq;
+    mreq.imr_multiaddr.s_addr = htonl(0xefff0000 | universe);
+    mreq.imr_address.s_addr = inet_addr(ifaddr);
+#endif
+    return setsockopt(sockfd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof mreq);
+}
+
 /* Initialize an E1.31 packet using a universe and a number of slots */
 int e131_pkt_init(e131_packet_t *packet, const uint16_t universe, const uint16_t num_slots) {
   if (packet == NULL || universe < 1 || universe > 63999 || num_slots < 1 || num_slots > 512) {

--- a/src/e131.h
+++ b/src/e131.h
@@ -141,6 +141,9 @@ extern int e131_multicast_join(int sockfd, const uint16_t universe);
 /* Join a socket file descriptor to an E1.31 multicast group using a universe and a specific network interface */
 extern int e131_multicast_join_iface(int sockfd, const uint16_t universe, const int ifindex);
 
+/* Join a socket file descriptor to an E1.31 multicast group using a universe and an IP address to bind to */
+extern int e131_multicast_join_ifaddr(int sockfd, const uint16_t universe, const char *ifaddr);
+
 /* Initialize an E1.31 packet using a universe and a number of slots */
 extern int e131_pkt_init(e131_packet_t *packet, const uint16_t universe, const uint16_t num_slots);
 


### PR DESCRIPTION
Hello!

This change allows for the user to specify an IP address on the host to bind to, rather than an interface index. I've found this to be helpful when working on a dual stack host.

An example of how this can be used:

```
if (e131_multicast_join_ifaddr(sockfd, 1, "1.2.3.4") < 0) {
    err(EXIT_FAILURE, "e131_multicast_join_ifaddr");
}
 ```

I've found working with the expected IP to bind to be easier to work with than the interface number for my projects.

Thanks for making this great library! I use it a lot!