### PR TITLE
Follow case-sensitive spelling of winsock2.h

### DIFF
--- a/src/e131.h
+++ b/src/e131.h
@@ -33,7 +33,7 @@ extern "C" {
 #include <sys/types.h>
 
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 #else
 #include <netinet/in.h>
 #endif


### PR DESCRIPTION
Including `WinSock2.h` doesn't work when cross-compiling with MinGW since the file is spelled `winsock2.h` and Linux is case-sensitive, unlike Windows.